### PR TITLE
Add Docker-based Go TODO app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/app
+/vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o app ./cmd/server
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /app/app ./app
+EXPOSE 8080
+CMD ["./app"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# go-todo-app
+# Go TODO App
+
+This is a simple TODO web application built for learning purposes. The project follows a clean architecture approach using the [Echo](https://echo.labstack.com/) framework and MySQL as the database. Development and execution can be done entirely using Docker.
+
+## Requirements
+- Docker
+- Docker Compose
+
+## Usage
+
+Build and start the application with MySQL:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available at `http://localhost:8080/api`.
+
+### Endpoints
+- `POST /api/todos` - create a new todo (JSON `{ "title": "task" }`)
+- `GET /api/todos` - list all todos
+- `PUT /api/todos/{id}` - mark a todo as completed
+
+## Project Structure
+
+- `cmd/server` - application entry point
+- `internal/entity` - domain models
+- `internal/repository` - repository interfaces
+- `internal/infrastructure/mysql` - MySQL implementation
+- `internal/usecase` - business logic
+- `internal/interface/controller` - HTTP handlers
+- `internal/router` - Echo router setup
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+
+	"github.com/example/go-todo-app/internal/entity"
+	"github.com/example/go-todo-app/internal/infrastructure/mysql"
+	"github.com/example/go-todo-app/internal/interface/controller"
+	"github.com/example/go-todo-app/internal/router"
+	"github.com/example/go-todo-app/internal/usecase"
+)
+
+func main() {
+	db, err := mysql.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := db.AutoMigrate(&entity.Todo{}); err != nil {
+		log.Fatal(err)
+	}
+
+	todoRepo := mysql.NewTodoRepository(db)
+	todoUsecase := usecase.NewTodoUsecase(todoRepo)
+	todoController := controller.NewTodoController(todoUsecase)
+
+	e := router.NewRouter(todoController)
+	if err := e.Start(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: todo
+      MYSQL_USER: todo
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+  app:
+    build: .
+    command: ["./app"]
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_USER: todo
+      DB_PASSWORD: password
+      DB_NAME: todo
+    ports:
+      - "8080:8080"
+volumes:
+  db-data:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/example/go-todo-app
+
+go 1.23.8
+
+require (
+	github.com/labstack/echo/v4 v4.11.1
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/gorm v1.25.2
+)

--- a/internal/entity/todo.go
+++ b/internal/entity/todo.go
@@ -1,0 +1,7 @@
+package entity
+
+type Todo struct {
+	ID        uint `gorm:"primaryKey;autoIncrement"`
+	Title     string
+	Completed bool
+}

--- a/internal/infrastructure/mysql/mysql.go
+++ b/internal/infrastructure/mysql/mysql.go
@@ -1,0 +1,20 @@
+package mysql
+
+import (
+	"fmt"
+	"os"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func New() (*gorm.DB, error) {
+	host := os.Getenv("DB_HOST")
+	port := os.Getenv("DB_PORT")
+	user := os.Getenv("DB_USER")
+	pass := os.Getenv("DB_PASSWORD")
+	name := os.Getenv("DB_NAME")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", user, pass, host, port, name)
+	return gorm.Open(mysql.Open(dsn), &gorm.Config{})
+}

--- a/internal/infrastructure/mysql/todo_repository.go
+++ b/internal/infrastructure/mysql/todo_repository.go
@@ -1,0 +1,31 @@
+package mysql
+
+import (
+	"github.com/example/go-todo-app/internal/entity"
+	"github.com/example/go-todo-app/internal/repository"
+	"gorm.io/gorm"
+)
+
+type todoRepository struct {
+	db *gorm.DB
+}
+
+func NewTodoRepository(db *gorm.DB) repository.TodoRepository {
+	return &todoRepository{db: db}
+}
+
+func (r *todoRepository) Create(todo *entity.Todo) error {
+	return r.db.Create(todo).Error
+}
+
+func (r *todoRepository) List() ([]*entity.Todo, error) {
+	var todos []*entity.Todo
+	if err := r.db.Find(&todos).Error; err != nil {
+		return nil, err
+	}
+	return todos, nil
+}
+
+func (r *todoRepository) Update(todo *entity.Todo) error {
+	return r.db.Save(todo).Error
+}

--- a/internal/interface/controller/todo_controller.go
+++ b/internal/interface/controller/todo_controller.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/example/go-todo-app/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type TodoController struct {
+	u usecase.TodoUsecase
+}
+
+func NewTodoController(u usecase.TodoUsecase) *TodoController {
+	return &TodoController{u: u}
+}
+
+func (c *TodoController) Register(g *echo.Group) {
+	g.POST("/todos", c.create)
+	g.GET("/todos", c.list)
+	g.PUT("/todos/:id", c.complete)
+}
+
+func (c *TodoController) create(ctx echo.Context) error {
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := ctx.Bind(&req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, err)
+	}
+	todo, err := c.u.Add(req.Title)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, err)
+	}
+	return ctx.JSON(http.StatusCreated, todo)
+}
+
+func (c *TodoController) list(ctx echo.Context) error {
+	todos, err := c.u.List()
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, err)
+	}
+	return ctx.JSON(http.StatusOK, todos)
+}
+
+func (c *TodoController) complete(ctx echo.Context) error {
+	idStr := ctx.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, err)
+	}
+	if err := c.u.Complete(uint(id)); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, err)
+	}
+	return ctx.NoContent(http.StatusOK)
+}

--- a/internal/repository/todo.go
+++ b/internal/repository/todo.go
@@ -1,0 +1,9 @@
+package repository
+
+import "github.com/example/go-todo-app/internal/entity"
+
+type TodoRepository interface {
+	Create(todo *entity.Todo) error
+	List() ([]*entity.Todo, error)
+	Update(todo *entity.Todo) error
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,13 @@
+package router
+
+import (
+	"github.com/example/go-todo-app/internal/interface/controller"
+	"github.com/labstack/echo/v4"
+)
+
+func NewRouter(todoController *controller.TodoController) *echo.Echo {
+	e := echo.New()
+	api := e.Group("/api")
+	todoController.Register(api)
+	return e
+}

--- a/internal/usecase/todo.go
+++ b/internal/usecase/todo.go
@@ -1,0 +1,51 @@
+package usecase
+
+import (
+	"github.com/example/go-todo-app/internal/entity"
+	"github.com/example/go-todo-app/internal/repository"
+)
+
+type TodoUsecase interface {
+	Add(title string) (*entity.Todo, error)
+	List() ([]*entity.Todo, error)
+	Complete(id uint) error
+}
+
+type todoUsecase struct {
+	repo repository.TodoRepository
+}
+
+func NewTodoUsecase(r repository.TodoRepository) TodoUsecase {
+	return &todoUsecase{repo: r}
+}
+
+func (u *todoUsecase) Add(title string) (*entity.Todo, error) {
+	todo := &entity.Todo{Title: title}
+	if err := u.repo.Create(todo); err != nil {
+		return nil, err
+	}
+	return todo, nil
+}
+
+func (u *todoUsecase) List() ([]*entity.Todo, error) {
+	return u.repo.List()
+}
+
+func (u *todoUsecase) Complete(id uint) error {
+	todos, err := u.repo.List()
+	if err != nil {
+		return err
+	}
+	var target *entity.Todo
+	for _, t := range todos {
+		if t.ID == id {
+			target = t
+			break
+		}
+	}
+	if target == nil {
+		return nil
+	}
+	target.Completed = true
+	return u.repo.Update(target)
+}


### PR DESCRIPTION
## Summary
- scaffold a clean architecture TODO app using Echo
- add MySQL repository implementation
- provide Dockerfile and docker-compose for local setup
- document usage in README

## Testing
- `go vet ./...` *(fails: missing go.sum entries due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68439ca70294832e9c8b5d2557e59ccb