### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Format
+        run: |
+          gofmt -w $(git ls-files '*.go')
+          git diff --exit-code
+
+      - name: Test
+        run: |
+          go test ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for gofmt check and running `go test`

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `go test ./...` *(fails: missing go.sum entries due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68439f569f54832e8996269c337b6b1f